### PR TITLE
add the initial implementation extracted from MuchRails

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,92 @@ Configuration for Ruby objects.
 
 ## Usage
 
-TODO: Write code samples and usage instructions here
+Mixin MuchConfig in your e.g. `MyClass` Ruby object. Call the `add_config` DSL method and define `MyClass::Config`:
+
+```ruby
+module MyClass
+  include MuchConfig
+
+  add_config
+
+  def self.value1
+    config.value1
+  end
+
+  class Config
+    attr_accessor :value1
+
+    def initialize
+      @value1 = "default value for `value1`"
+    end
+  end
+end
+```
+
+Configure MyClass using the MuchConfig API:
+
+```ruby
+MyClass.config.value1 = "a custom value"
+
+# OR
+
+MyClass.configure do |config|
+  config.value1 = "a custom value"
+end
+```
+
+### Define multiple named configs
+
+You can define multiple named configs, e.g.:
+
+```ruby
+module MyClass
+  include MuchConfig
+
+  add_config :values
+  add_config :settings
+
+  def self.value1
+    values_config.value1
+  end
+
+  def self.setting1
+    settings_config.setting1
+  end
+
+  class ValuesConfig
+    attr_accessor :value1
+
+    def initialize
+      @value1 = "default value for `value1`"
+    end
+  end
+
+  class SettingsConfig
+    attr_accessor :setting1
+
+    def initialize
+      @setting1 = "default value for `setting1`"
+    end
+  end
+end
+```
+
+Configure using the MuchConfig API:
+
+```ruby
+MyClass.values_config.value1 = "a custom value"
+MyClass.settings_config.setting1 = "a custom value"
+
+# OR
+
+MyClass.configure_values do |config|
+  config.value1 = "a custom value"
+end
+MyClass.configure_settings do |config|
+  config.setting1 = "a custom value"
+end
+```
 
 ## Installation
 

--- a/lib/much-config.rb
+++ b/lib/much-config.rb
@@ -1,6 +1,79 @@
 # frozen_string_literal: true
 
 require "much-config/version"
+require "much-mixin"
 
 module MuchConfig
+  include MuchMixin
+
+  def self.classify(term)
+    # prefer to ActiveSupport if present
+    return term.classify if term.respond_to?(:classify)
+
+    value = term.sub(/^[a-z\d]*/, &:capitalize)
+    value.gsub!(%r{(?:_|(/))([a-z\d]*)}i) do
+      "#{Regexp.last_match(1)}#{Regexp.last_match(2).capitalize}"
+    end
+    value.gsub!("/", "::")
+    value
+  end
+
+  def self.underscore(cased_term)
+    # prefer to ActiveSupport if present
+    return cased_term.underscore if cased_term.respond_to?(:underscore)
+
+    return cased_term unless /[A-Z-]|::/.match?(cased_term)
+
+    term = cased_term.to_s.gsub("::", "/")
+    term.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+    term.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+    term.tr!("-", "_")
+    term.downcase!
+    term
+  end
+
+  mixin_class_methods do
+    def add_config(name = nil, method_name: nil)
+      config_method_name, config_class_name, configure_method_name =
+        much_config_names(name, method_name)
+
+      instance_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+        def #{config_method_name}
+          @#{config_method_name} ||= self::#{config_class_name}.new
+        end
+
+        def #{configure_method_name}
+          yield(#{config_method_name}) if block_given?
+        end
+      RUBY
+    end
+
+    def add_instance_config(name = nil, method_name: nil)
+      config_method_name, config_class_name, configure_method_name =
+        much_config_names(name, method_name)
+
+      instance_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+        define_method(:#{config_method_name}) do
+          @#{config_method_name} ||= self.class::#{config_class_name}.new
+        end
+
+        define_method(:#{configure_method_name}) do |&block|
+          block.call(#{config_method_name}) if block
+        end
+      RUBY
+    end
+
+    private
+
+    def much_config_names(name, method_name)
+      name_prefix = name.nil? ? "" : "#{MuchConfig.underscore(name.to_s)}_"
+      config_method_name = (method_name || "#{name_prefix}config").to_s
+      config_class_name = "#{MuchConfig.classify(name_prefix)}Config"
+
+      name_suffix = name.nil? ? "" : "_#{MuchConfig.underscore(name.to_s)}"
+      configure_method_name = "configure#{name_suffix}"
+
+      [config_method_name, config_class_name, configure_method_name]
+    end
+  end
 end

--- a/much-config.gemspec
+++ b/much-config.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("much-style-guide", ["~> 0.6.4"])
   gem.add_development_dependency("assert",           ["~> 2.19.6"])
+
+  gem.add_dependency("much-mixin", ["~> 0.2.4"])
 end

--- a/test/unit/much-config_tests.rb
+++ b/test/unit/much-config_tests.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "assert"
+require "much-config"
+
+require "much-mixin"
+
+module MuchConfig
+  class UnitTests < Assert::Context
+    desc "MuchConfig"
+    subject{ unit_class }
+
+    let(:unit_class){ MuchConfig }
+
+    should "be configured as expected" do
+      assert_that(subject).includes(MuchMixin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject{ receiver_class }
+
+    setup do
+      class receiver_class::Config
+        attr_accessor :value
+      end
+
+      class receiver_class::AnotherConfig
+        include MuchConfig
+
+        add_instance_config :sub, method_name: :sub
+
+        attr_accessor :another_value
+
+        class SubConfig
+          attr_accessor :sub_value
+        end
+      end
+    end
+
+    let(:receiver_class) do
+      Class.new do
+        include MuchConfig
+
+        add_config
+        add_config :another
+      end
+    end
+
+    should have_imeths :config, :another_config
+
+    should "know its attributes" do
+      assert_that(subject.config).is_instance_of(subject::Config)
+      subject.configure{ |config| config.value = "VALUE 1" }
+      assert_that(subject.config.value).equals("VALUE 1")
+
+      assert_that(subject.another_config).is_instance_of(subject::AnotherConfig)
+      subject.configure_another{ |config| config.another_value = "VALUE 2" }
+      assert_that(subject.another_config.another_value).equals("VALUE 2")
+
+      assert_that(subject.another_config.sub)
+        .is_instance_of(subject::AnotherConfig::SubConfig)
+      subject.another_config.configure_sub do |sub|
+        sub.sub_value = "VALUE 3"
+      end
+      assert_that(subject.another_config.sub.sub_value).equals("VALUE 3")
+    end
+  end
+end


### PR DESCRIPTION
I'm extracting this from MuchRails so that we can use it outside
of the context of a Rails app. This is the implementation from
MuchRails adapted for being its own gem.

This also adds a first-pass README to give some documentation on
how to use the API.
